### PR TITLE
Add DepenancySide to IModInfo

### DIFF
--- a/src/main/java/net/minecraftforge/forgespi/language/IModInfo.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IModInfo.java
@@ -44,6 +44,8 @@ public interface IModInfo
 
     ArtifactVersion getVersion();
 
+    DependencySide getSide();
+
     List<? extends ModVersion> getDependencies();
 
     List<? extends ForgeFeature.Bound> getForgeFeatures();


### PR DESCRIPTION
After some discussion in the [discord](https://discord.com/channels/313125603924639766/313125603924639766/1157126571807752252) about how easy it is for users to drop a server side on the client and crash the server. To make the crash less opaque I propose we require modders to declare the side their mod is on during construction. ~I am working on a sibling PR for FML that will be up shortly~

[FML PR](https://github.com/neoforged/FancyModLoader/pull/23)